### PR TITLE
Allow customization of embedder backend

### DIFF
--- a/bitdoze_bot/agents.py
+++ b/bitdoze_bot/agents.py
@@ -20,7 +20,6 @@ from agno.learn import (
     UserProfileConfig,
 )
 from agno.knowledge import Knowledge
-from agno.knowledge.embedder.openai import OpenAIEmbedder
 from agno.models.openai.like import OpenAILike
 from agno.session import SessionSummaryManager
 from agno.skills import LocalSkills, SkillLoader, Skills
@@ -40,6 +39,7 @@ from bitdoze_bot.cognee import CogneeClient, load_cognee_config
 from bitdoze_bot.cognee_tools import CogneeTools
 from bitdoze_bot.config import Config
 from bitdoze_bot.discovery_tools import DiscoveryTools
+from bitdoze_bot.embedder import build_embedder
 from bitdoze_bot.tool_permissions import ToolPermissionManager, get_tool_runtime_context
 from bitdoze_bot.utils import read_text_if_exists
 
@@ -526,12 +526,11 @@ def _build_knowledge(config: Config) -> tuple[Any, Any]:
         return None, None
 
     backend = str(kb_cfg.get("backend", "lancedb")).lower()
-    embedder_id = kb_cfg.get("embedder", "text-embedding-3-small")
-    embedder = OpenAIEmbedder(id=embedder_id)
+    embedder = build_embedder(config)
     logger.info(
         "Knowledge enabled backend=%s embedder=%s table=%s learnings_table=%s",
         backend,
-        embedder_id,
+        embedder.id,
         kb_cfg.get("table_name", "bitdoze_knowledge"),
         kb_cfg.get("learnings_table_name", "bitdoze_learnings"),
     )

--- a/bitdoze_bot/embedder.py
+++ b/bitdoze_bot/embedder.py
@@ -1,0 +1,88 @@
+"""Embedder builder with configurable endpoint support.
+
+Provides build_embedder() to create an OpenAIEmbedder with optional
+endpoint customization. Falls back to main model's base_url and api_key_env
+when not specified in embedder config.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any
+
+from agno.knowledge.embedder.openai import OpenAIEmbedder
+
+from bitdoze_bot.config import Config
+
+logger = logging.getLogger(__name__)
+
+
+def _require_env(var_name: str) -> str:
+    """Get required environment variable or raise error."""
+    value = os.getenv(var_name, "").strip()
+    if not value:
+        raise ValueError(f"Missing required environment variable: {var_name}")
+    return value
+
+
+def build_embedder(config: Config) -> OpenAIEmbedder:
+    """Build an OpenAIEmbedder from config.
+
+    Reads knowledge.embedder config which can be:
+    - A string (model id): uses main model's base_url and api_key_env
+    - A mapping with id, base_url, api_key_env for custom endpoint
+
+    Falls back to main model's base_url and api_key_env when not specified
+    in embedder config.
+
+    Args:
+        config: Application config object.
+
+    Returns:
+        Configured OpenAIEmbedder instance.
+    """
+    kb_cfg = config.get("knowledge", default={}) or {}
+    model_cfg = config.get("model", default={}) or {}
+
+    # Get embedder config (string or mapping)
+    embedder_cfg = kb_cfg.get("embedder", "text-embedding-3-small")
+
+    # Parse embedder config
+    if isinstance(embedder_cfg, str):
+        # String format: just model id
+        embedder_id = embedder_cfg
+        embedder_base_url = model_cfg.get("base_url")
+        embedder_api_key_env = model_cfg.get("api_key_env", "OPENAI_API_KEY")
+    elif isinstance(embedder_cfg, dict):
+        # Mapping format: id, base_url, api_key_env
+        embedder_id = embedder_cfg.get("id", "text-embedding-3-small")
+        embedder_base_url = embedder_cfg.get("base_url", model_cfg.get("base_url"))
+        embedder_api_key_env = embedder_cfg.get(
+            "api_key_env", model_cfg.get("api_key_env", "OPENAI_API_KEY")
+        )
+    else:
+        # Fallback to default
+        logger.warning(
+            "Unexpected embedder config type: %s, using defaults",
+            type(embedder_cfg).__name__,
+        )
+        embedder_id = "text-embedding-3-small"
+        embedder_base_url = model_cfg.get("base_url")
+        embedder_api_key_env = model_cfg.get("api_key_env", "OPENAI_API_KEY")
+
+    # Get API key from environment
+    api_key = _require_env(embedder_api_key_env)
+
+    logger.info(
+        "Embedder id=%s base_url=%s api_key_env=%s",
+        embedder_id,
+        embedder_base_url or "default",
+        embedder_api_key_env,
+    )
+
+    return OpenAIEmbedder(
+        id=embedder_id,
+        api_key=api_key,
+        base_url=embedder_base_url,
+    )

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -109,7 +109,7 @@ memory:
 knowledge:
     enabled: false # set to true after running setup_knowledge.py
     backend: lancedb # lancedb (file-based, no docker) or pgvector (requires PostgreSQL)
-    embedder: text-embedding-3-small
+    embedder: text-embedding-3-small # model id; or dict with id/base_url/api_key_env (defaults to model.*)
     # LanceDb settings (used when backend=lancedb)
     lance_uri: data/lancedb
     table_name: bitdoze_knowledge

--- a/scripts/setup_knowledge.py
+++ b/scripts/setup_knowledge.py
@@ -51,12 +51,12 @@ def main() -> None:
 
     kb_cfg = config.get("knowledge", default={}) or {}
     backend = args.backend or kb_cfg.get("backend", "lancedb")
-    embedder_id = kb_cfg.get("embedder", "text-embedding-3-small")
 
     from agno.knowledge import Knowledge
-    from agno.knowledge.embedder.openai import OpenAIEmbedder
 
-    embedder = OpenAIEmbedder(id=embedder_id)
+    from bitdoze_bot.embedder import build_embedder
+
+    embedder = build_embedder(config)
 
     if backend == "pgvector":
         try:

--- a/tests/test_embedder.py
+++ b/tests/test_embedder.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+from bitdoze_bot.config import Config
+from bitdoze_bot.embedder import build_embedder
+
+
+def test_embedder_string_uses_model_endpoint(tmp_path: Path) -> None:
+    config = Config(
+        data={"model": {"base_url": "https://api.example.com/v1", "api_key_env": "MODEL_KEY"},
+              "knowledge": {"embedder": "text-embedding-3-small"}},
+        path=tmp_path / "config.yaml",
+    )
+    with patch.dict(os.environ, {"MODEL_KEY": "test-key"}):
+        e = build_embedder(config)
+    assert e.id == "text-embedding-3-small"
+    assert e.base_url == "https://api.example.com/v1"
+
+
+def test_embedder_dict_custom_endpoint(tmp_path: Path) -> None:
+    config = Config(
+        data={"knowledge": {"embedder": {"id": "custom-model", "base_url": "https://embed.com/v1", "api_key_env": "EMBED_KEY"}}},
+        path=tmp_path / "config.yaml",
+    )
+    with patch.dict(os.environ, {"EMBED_KEY": "embed-key"}):
+        e = build_embedder(config)
+    assert e.id == "custom-model"
+    assert e.base_url == "https://embed.com/v1"
+
+
+def test_embedder_dict_partial_fallback(tmp_path: Path) -> None:
+    config = Config(
+        data={"model": {"base_url": "https://api.example.com/v1", "api_key_env": "MODEL_KEY"},
+              "knowledge": {"embedder": {"id": "text-embedding-3-large"}}},
+        path=tmp_path / "config.yaml",
+    )
+    with patch.dict(os.environ, {"MODEL_KEY": "model-key"}):
+        e = build_embedder(config)
+    assert e.id == "text-embedding-3-large"
+    assert e.base_url == "https://api.example.com/v1"
+
+
+def test_embedder_missing_api_key_raises(tmp_path: Path) -> None:
+    config = Config(data={"model": {"api_key_env": "MISSING_KEY"}}, path=tmp_path / "config.yaml")
+    try:
+        build_embedder(config)
+        raise AssertionError("Expected ValueError")
+    except ValueError as e:
+        assert "MISSING_KEY" in str(e)


### PR DESCRIPTION
The current embedding model is hard coded to use the openai backend. This is inconsistent with the main model configuration which allows override of base_url. The PR added option to configure embedding model in a similar manner.

# Changes
  - bitdoze_bot/embedder.py - New module with build_embedder() function that supports:
  - bitdoze_bot/agents.py - Replaced hardcoded OpenAIEmbedder(id=...) with build_embedder(config) call
  - config.example.yaml - Updated embedder documentation to show mapping format support
  - scripts/setup_knowledge.py - Updated to use new embedder builder
  - tests/test_embedder.py - Added tests for embedder configuration scenarios

# Configuration Examples
## Default (OpenAI):

```
  knowledge:
    embedder: text-embedding-3-small
```

## Custom endpoint (e.g., Ollama):

```
  knowledge:
    embedder:
      id: nomic-embed-text
      base_url: http://localhost:11434/v1
      api_key_env: OLLAMA_API_KEY
```

# Testing
```
  uv run pytest tests/test_embedder.py
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Embedder configuration now supports flexible setup via dictionary format, allowing custom base URL and API key environment variable specification in addition to model identifier strings.

* **Documentation**
  * Updated configuration documentation to reflect expanded embedder configuration options and defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->